### PR TITLE
Fix _CursorWithTransaction's __aexit__ not being invoked

### DIFF
--- a/asqlite.py
+++ b/asqlite.py
@@ -110,7 +110,7 @@ class _ContextManagerMixin:
 
     async def __aexit__(self, exc_type, exc, tb):
         if self.__result is not None:
-            await self.__result.close()
+            await self.__result.__aexit__(exc_type, exc, tb)
 
 class Cursor:
     """An asyncio-compatible version of :class:`sqlite3.Cursor`.


### PR DESCRIPTION
Due to `_ContextManagerMixin` only invoking the result's `close()` method when exiting and `_CursorWithTransaction` only inheriting the method from `Cursor`, it misses the commit/rollback logic implemented in `__aexit__`:
```py
async with asqlite.connect(...) as conn:
    async with conn.cursor(transaction=True) as c:
        # cursor.start(); transaction begins
        await c.execute(...)
    # cursor.close(); forgets to commit
```
This resolves the issue by having the mixin call the `__aexit__` method instead. For other classes (`Cursor` and `Connection`), this change will have no effect as those also call the `close()` method when exiting.